### PR TITLE
fix: Global Header Checking Url #13

### DIFF
--- a/src/components/globalHeader/GlobalHeader.tsx
+++ b/src/components/globalHeader/GlobalHeader.tsx
@@ -7,8 +7,8 @@ export const GlobalHeader = () => {
   const [textColor, setTextColor] = useState([false, false, false])
   const { pathname } = useLocation()
   useEffect(() => {
-    const page = pathname.slice(1)
-    textColorHandler(page)
+    const page = pathname.split('/')
+    textColorHandler(page[1])
   }, [])
 
   const textColorHandler = (page: string) => {


### PR DESCRIPTION
## Description
Url 검사를 통해서 글로벌 헤더, Info 헤더의 텍스트 색을 부여한다.
수정 전은 인덱스로 문자열을 필터링을 한다. 

글로벌 헤더는 상위 라우트 path만 봐야하는데 하위 url까지 검사에 반영되는 문제가 생겼다.

## Todo
- [x] Filtering by String